### PR TITLE
Bug - each container was generating a new master password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN set -x \
     && mkdir -p /usr/local/sbin \
 
     # Install minimal packages
-    && apk add --no-cache ca-certificates wget ssmtp 'su-exec>=0.2' \
+    && apk add --update --no-cache ca-certificates wget ssmtp 'su-exec>=0.2' \
 
     # Install s6 overlay
     && wget https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz --no-check-certificate -O /tmp/s6-overlay.tar.gz \

--- a/rootfs/etc/cont-init.d/00-00-daspanel-base
+++ b/rootfs/etc/cont-init.d/00-00-daspanel-base
@@ -13,40 +13,74 @@ if [ -z "$DASPANEL_SYS_UUID" ]; then
     exit 1
 fi
 
-# unless this has already been defined, set
-if [ -z "$DASPANEL_SYS_HOST" ]; then
-    export DASPANEL_SYS_HOST="daspanel.site"
-    echo "[DASPANEL] DEFAULT: DASPANEL_SYS_HOST=$DASPANEL_SYS_HOST"
-fi
+if [ ! -f /opt/daspanel/data/$DASPANEL_SYS_UUID/db/sysconfig.json ]; then
 
-# unless this has already been defined, set
-if [ -z "$DASPANEL_SYS_ADMIN" ]; then
-    export DASPANEL_SYS_ADMIN="admin@$DASPANEL_SYS_HOST"
-    echo "[DASPANEL] DEFAULT: DASPANEL_SYS_ADMIN=$DASPANEL_SYS_ADMIN"
-fi
+    # unless this has already been defined, set
+    if [ -z "$DASPANEL_SYS_HOST" ]; then
+        export DASPANEL_SYS_HOST="daspanel.site"
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_HOST=$DASPANEL_SYS_HOST"
+    fi
 
-# unless this has already been defined, set 
-if [ -z "$DASPANEL_SYS_PASSWORD" ]; then
-    export DASPANEL_SYS_PASSWORD=`date +%s | sha256sum | base64 | head -c 16 ; echo`
-    echo "[DASPANEL] DEFAULT: DASPANEL_SYS_PASSWORD=$DASPANEL_SYS_PASSWORD"
-fi
+    # unless this has already been defined, set
+    if [ -z "$DASPANEL_SYS_ADMIN" ]; then
+        export DASPANEL_SYS_ADMIN="admin@$DASPANEL_SYS_HOST"
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_ADMIN=$DASPANEL_SYS_ADMIN"
+    fi
 
-# unless this has already been defined, set
-if [ -z "$DASPANEL_SYS_MSGHUB" ]; then
-    export DASPANEL_SYS_MSGHUB="mail-catcher"
-    echo "[DASPANEL] DEFAULT: DASPANEL_SYS_MSGHUB=$DASPANEL_SYS_MSGHUB"
-fi
+    # unless this has already been defined, set 
+    if [ -z "$DASPANEL_SYS_PASSWORD" ]; then
+        export DASPANEL_SYS_PASSWORD=`date +%s | sha256sum | base64 | head -c 16 ; echo`
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_PASSWORD=$DASPANEL_SYS_PASSWORD"
+    fi
 
-# unless this has already been defined, set
-if [ -z "$DASPANEL_SYS_APISERVER" ]; then
-    export DASPANEL_SYS_APISERVER="http://daspanel-api:8080/1.0"
-    echo "[DASPANEL] DEFAULT: DASPANEL_SYS_APISERVER=$DASPANEL_SYS_APISERVER"
-fi
+    # unless this has already been defined, set
+    if [ -z "$DASPANEL_SYS_MSGHUB" ]; then
+        export DASPANEL_SYS_MSGHUB="mail-catcher"
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_MSGHUB=$DASPANEL_SYS_MSGHUB"
+    fi
 
-# unless this has already been defined, set
-if [ -z "$DASPANEL_SYS_DEBUG" ]; then
-    export DASPANEL_SYS_DEBUG=False
-    echo "[DASPANEL] DEFAULT: DASPANEL_SYS_DEBUG=$DASPANEL_SYS_DEBUG"
+    # unless this has already been defined, set
+    if [ -z "$DASPANEL_SYS_APISERVER" ]; then
+        export DASPANEL_SYS_APISERVER="http://daspanel-api:8080/1.0"
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_APISERVER=$DASPANEL_SYS_APISERVER"
+    fi
+
+    # unless this has already been defined, set
+    if [ -z "$DASPANEL_SYS_DEBUG" ]; then
+        export DASPANEL_SYS_DEBUG=False
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_DEBUG=$DASPANEL_SYS_DEBUG"
+    fi
+else
+    if [ -z "$DASPANEL_SYS_HOST" ]; then
+        export DASPANEL_SYS_HOST=`cat /opt/daspanel/data/$DASPANEL_SYS_UUID/db/sysconfig.json | /usr/bin/jq -r '.sys.hostname'`
+    else
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_HOST=$DASPANEL_SYS_HOST"
+    fi
+    if [ -z "$DASPANEL_SYS_ADMIN" ]; then
+        export DASPANEL_SYS_ADMIN=`cat /opt/daspanel/data/$DASPANEL_SYS_UUID/db/sysconfig.json | /usr/bin/jq -r '.sys.admin'`
+    else
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_ADMIN=$DASPANEL_SYS_ADMIN"
+    fi
+    if [ -z "$DASPANEL_SYS_PASSWORD" ]; then
+        export DASPANEL_SYS_PASSWORD=`cat /opt/daspanel/data/$DASPANEL_SYS_UUID/db/sysconfig.json | /usr/bin/jq -r '.sys.password'`
+    else
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_PASSWORD=$DASPANEL_SYS_PASSWORD"
+    fi
+    if [ -z "$DASPANEL_SYS_MSGHUB" ]; then
+        export DASPANEL_SYS_MSGHUB=`cat /opt/daspanel/data/$DASPANEL_SYS_UUID/db/sysconfig.json | /usr/bin/jq -r '.sys.msghub'`
+    else
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_MSGHUB=$DASPANEL_SYS_MSGHUB"
+    fi
+    if [ -z "$DASPANEL_SYS_APISERVER" ]; then
+        export DASPANEL_SYS_APISERVER=`cat /opt/daspanel/data/$DASPANEL_SYS_UUID/db/sysconfig.json | /usr/bin/jq -r '.sys.apiserver'`
+    else
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_APISERVER=$DASPANEL_SYS_APISERVER"
+    fi
+    if [ -z "$DASPANEL_SYS_DEBUG" ]; then
+        export DASPANEL_SYS_DEBUG=`cat /opt/daspanel/data/$DASPANEL_SYS_UUID/db/sysconfig.json | /usr/bin/jq -r '.sys.debug'`
+    else
+        echo "[DASPANEL] DEFAULT: DASPANEL_SYS_DEBUG=$DASPANEL_SYS_DEBUG"
+    fi
 fi
 
 if [ ! -d "/opt/daspanel/data/$DASPANEL_SYS_UUID" ]; then
@@ -97,27 +131,25 @@ else
 fi
 
 # Compatible layer with old init system, remove after all containers are using the new init/configuration system
-DASPANEL_HOST=$DASPANEL_SYS_HOST
-DASPANEL_GUUID=$DASPANEL_SYS_UUID
-DASPANEL_MASTER_EMAIL=$DASPANEL_SYS_ADMIN
-DASPANEL_MASTER_PASSWORD=$DASPANEL_SYS_PASSWORD
-DASPANEL_DEBUG=$DASPANEL_SYS_DEBUG
+#DASPANEL_HOST=$DASPANEL_SYS_HOST
+#DASPANEL_GUUID=$DASPANEL_SYS_UUID
+#DASPANEL_MASTER_EMAIL=$DASPANEL_SYS_ADMIN
+#DASPANEL_MASTER_PASSWORD=$DASPANEL_SYS_PASSWORD
+#DASPANEL_DEBUG=$DASPANEL_SYS_DEBUG
+#DASPANEL_MAIL_HUB=$DASPANEL_SYS_MSGHUB
+#DASPANEL_MAIL_SERVER="daspanel-mail-catcher:1025"
+#DASPANEL_MAIL_USER=$DASPANEL_SYS_ADMIN
+#DASPANEL_MAIL_PWD=$DASPANEL_SYS_UUID
 
-DASPANEL_MAIL_HUB=$DASPANEL_SYS_MSGHUB
-DASPANEL_MAIL_SERVER="daspanel-mail-catcher:1025"
-DASPANEL_MAIL_USER=$DASPANEL_SYS_ADMIN
-DASPANEL_MAIL_PWD=$DASPANEL_SYS_UUID
-
-printf $DASPANEL_HOST > /var/run/s6/container_environment/DASPANEL_HOST
-printf $DASPANEL_GUUID > /var/run/s6/container_environment/DASPANEL_GUUID
-printf $DASPANEL_MASTER_EMAIL > /var/run/s6/container_environment/DASPANEL_MASTER_EMAIL
-printf $DASPANEL_MASTER_PASSWORD > /var/run/s6/container_environment/DASPANEL_MASTER_PASSWORD
-printf $DASPANEL_DEBUG > /var/run/s6/container_environment/DASPANEL_DEBUG
-
-printf $DASPANEL_MAIL_HUB > /var/run/s6/container_environment/DASPANEL_MAIL_HUB
-printf $DASPANEL_MAIL_SERVER > /var/run/s6/container_environment/DASPANEL_MAIL_SERVER
-printf $DASPANEL_MAIL_USER > /var/run/s6/container_environment/DASPANEL_MAIL_USER
-printf $DASPANEL_MAIL_PWD > /var/run/s6/container_environment/DASPANEL_MAIL_PWD
+#echo "$DASPANEL_HOST" > /var/run/s6/container_environment/DASPANEL_HOST
+#echo "$DASPANEL_GUUID" > /var/run/s6/container_environment/DASPANEL_GUUID
+#echo "$DASPANEL_MASTER_EMAIL" > /var/run/s6/container_environment/DASPANEL_MASTER_EMAIL
+#echo "$DASPANEL_MASTER_PASSWORD" > /var/run/s6/container_environment/DASPANEL_MASTER_PASSWORD
+#echo "$DASPANEL_DEBUG" > /var/run/s6/container_environment/DASPANEL_DEBUG
+#echo "$DASPANEL_MAIL_HUB" > /var/run/s6/container_environment/DASPANEL_MAIL_HUB
+#echo "$DASPANEL_MAIL_SERVER" > /var/run/s6/container_environment/DASPANEL_MAIL_SERVER
+#echo "$DASPANEL_MAIL_USER" > /var/run/s6/container_environment/DASPANEL_MAIL_USER
+#echo "$DASPANEL_MAIL_PWD" > /var/run/s6/container_environment/DASPANEL_MAIL_PWD
 
 # secure daspanel
 chown -R daspanel:daspanel /opt/daspanel/data


### PR DESCRIPTION
Each container, when booting, was generating a new master password in sysconfig.json. Fixed.